### PR TITLE
I dont need no stinking orm

### DIFF
--- a/sanic_security/authentication.py
+++ b/sanic_security/authentication.py
@@ -38,13 +38,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 password_hasher = PasswordHasher()
 
 async def register(
-    request: Request, verified: bool = False, disabled: bool = False
+    request: dict, verified: bool = False, disabled: bool = False
 ):
     """
     Registers a new account that can be logged into.
 
     Args:
-        request (Request): Sanic request parameter. All request bodies are sent as form-data with the following arguments: email, username, password, phone (including country code).
+        request (Request): Sanic request parameter. All requests are sent as a dict with the following arguments: email, username, password, phone (including country code).
         verified (bool): Enables or disabled the verification requirement for the account being registered.
         disabled (bool): Renders an account unusable until manually set to false if designated true.
 
@@ -59,22 +59,22 @@ async def register(
 
     # Input validation should be handled in the ORM itself
     try:
-        if await _orm.account.lookup(email=request.form.get("email").lower()):
+        if await _orm.account.lookup(email=request.get("email").lower()):
             raise CredentialsError("An account with this email already exists.")
     except NotFoundError:
         try:
           if (
               security_config.SANIC_SECURITY_ALLOW_LOGIN_WITH_USERNAME
-              and await _orm.account.lookup(username=request.form.get("username"))
+              and await _orm.account.lookup(username=request.get("username"))
           ):
               raise CredentialsError("An account with this username already exists.")
         except NotFoundError:
             try:
                 account = await _orm.account.new(
-                    email=request.form.get("email").lower(),
-                    username=request.form.get("username"),
-                    password=password_hasher.hash(request.form.get("password")),
-                    phone=request.form.get("phone"),
+                    email=request.get("email").lower(),
+                    username=request.get("username"),
+                    password=password_hasher.hash(request.get("password")),
+                    phone=request.get("phone"),
                     verified=verified,
                     disabled=disabled,
                 )

--- a/tests/server.py
+++ b/tests/server.py
@@ -101,7 +101,7 @@ def make_app():
         Register an account with email and password.
         """
         account = await register(
-            request,
+            request.form,
             verified=request.form.get("verified") == "true",
             disabled=request.form.get("disabled") == "true",
         )


### PR DESCRIPTION
- `register` no longer requires a form -- it requires a `dict`
- You can now load config values from environment, as well as Sanic (assuming they were loaded before you `init_app()`)