### PR TITLE
Moved `.encode()` and `.decode_raw()` from models to `utils` module

### DIFF
--- a/sanic_security/exceptions.py
+++ b/sanic_security/exceptions.py
@@ -1,6 +1,6 @@
 from sanic.exceptions import SanicException
 
-from sanic_security.utils import json
+from sanic.response import json
 
 """
 An effective, simple, and async security library for the Sanic framework.
@@ -34,7 +34,7 @@ class SecurityError(SanicException):
     """
 
     def __init__(self, message: str, code: int):
-        self.json_response = json(message, self.__class__.__name__, code)
+        self.json_response = json({"message": message, "data": self.__class__.__name__, "code": code}, status=code)
         super().__init__(message, code)
 
 

--- a/sanic_security/orm/tortoise.py
+++ b/sanic_security/orm/tortoise.py
@@ -1,8 +1,6 @@
 import datetime
 from types import SimpleNamespace
 
-import jwt
-from jwt import DecodeError
 from sanic.log import logger
 from sanic.request import Request
 from sanic.response import HTTPResponse
@@ -16,7 +14,7 @@ import phonenumbers
 
 from sanic_security.configuration import config as security_config
 from sanic_security.exceptions import *
-from sanic_security.utils import get_ip, get_code, get_expiration_date
+from sanic_security.utils import get_ip, get_code, get_expiration_date, decode_raw
 
 """
 An effective, simple, and async security library for the Sanic framework.
@@ -344,67 +342,6 @@ class Session(BaseModel):
         elif not self.active:
             raise DeactivatedError()
 
-    def encode(self, response: HTTPResponse) -> None:
-        """
-        Transforms session into JWT and then is stored in a cookie.
-
-        Args:
-            response (HTTPResponse): Sanic response used to store JWT into a cookie on the client.
-        """
-        payload = {
-            "id": self.id,
-            "date_created": str(self.date_created),
-            "expiration_date": str(self.expiration_date),
-            "ip": self.ip,
-            **self.ctx.__dict__,
-        }
-        cookie = f"{security_config.SANIC_SECURITY_SESSION_PREFIX}_{self.__class__.__name__.lower()[:4]}_session"
-        encoded_session = jwt.encode(
-            payload, security_config.SANIC_SECURITY_SECRET, security_config.SANIC_SECURITY_SESSION_ENCODING_ALGORITHM
-        )
-        if isinstance(encoded_session, bytes):
-            response.cookies[cookie] = encoded_session.decode()
-        elif isinstance(encoded_session, str):
-            response.cookies[cookie] = encoded_session
-        response.cookies[cookie]["httponly"] = security_config.SANIC_SECURITY_SESSION_HTTPONLY
-        response.cookies[cookie]["samesite"] = security_config.SANIC_SECURITY_SESSION_SAMESITE
-        response.cookies[cookie]["secure"] = security_config.SANIC_SECURITY_SESSION_SECURE
-        if security_config.SANIC_SECURITY_SESSION_EXPIRES_ON_CLIENT and self.expiration_date:
-            response.cookies[cookie]["expires"] = self.expiration_date
-        if security_config.SANIC_SECURITY_SESSION_DOMAIN:
-            response.cookies[cookie]["domain"] = security_config.SANIC_SECURITY_SESSION_DOMAIN
-
-    @classmethod
-    def decode_raw(cls, request: Request) -> dict:
-        """
-        Decodes JWT token from client cookie into a python dict.
-
-        Args:
-            request (Request): Sanic request parameter.
-
-        Returns:
-            session_dict
-
-        Raises:
-            JWTDecodeError
-        """
-        cookie = request.cookies.get(
-            f"{security_config.SANIC_SECURITY_SESSION_PREFIX}_{cls.__name__.lower()[:4]}_session"
-        )
-        try:
-            if not cookie:
-                raise JWTDecodeError("Session token not provided.")
-            else:
-                return jwt.decode(
-                    cookie,
-                    security_config.SANIC_SECURITY_SECRET
-                    if not security_config.SANIC_SECURITY_PUBLIC_SECRET
-                    else security_config.SANIC_SECURITY_PUBLIC_SECRET,
-                    security_config.SANIC_SECURITY_SESSION_ENCODING_ALGORITHM,
-                )
-        except DecodeError as e:
-            raise JWTDecodeError(str(e))
-
     @classmethod
     async def decode(cls, request: Request):
         """
@@ -421,7 +358,7 @@ class Session(BaseModel):
             NotFoundError
         """
         try:
-            decoded_raw = cls.decode_raw(request)
+            decoded_raw = decode_raw(cls, request)
             decoded_session = (
                 await cls.filter(id=decoded_raw["id"]).prefetch_related("bearer").get()
             )
@@ -441,7 +378,6 @@ class Session(BaseModel):
             session
 
         Raises:
-            JWTDecodeError
             NotFoundError
         """
         # TODO: Should probably be removing old sessions, not just setting inactive

--- a/tests/server.py
+++ b/tests/server.py
@@ -22,7 +22,7 @@ from sanic_security.authorization import (
 from sanic_security.captcha import request_captcha, requires_captcha
 from sanic_security.configuration import config as security_config
 from sanic_security.exceptions import SecurityError, IntegrityError
-from sanic_security.utils import json, get_image
+from sanic_security.utils import json, get_image, encode
 from sanic_security.verification import (
     request_two_step_verification,
     requires_two_step_verification,
@@ -110,7 +110,7 @@ def make_app():
             response = json(
                 "Registration successful! Verification required.", two_step_session.code
             )
-            two_step_session.encode(response)
+            encode(two_step_session, response)
         else:
             response = json("Registration successful!", await account.json())
         return response
@@ -134,7 +134,7 @@ def make_app():
         """
         authentication_session = await login(request)
         response = json("Login successful!", await authentication_session.json())
-        authentication_session.encode(response)
+        encode(authentication_session, response)
         return response
 
 
@@ -155,7 +155,7 @@ def make_app():
         Check if current authentication session is valid.
         """
         response = json("Authenticated!", await authentication_session.json())
-        authentication_session.encode(response)
+        encode(authentication_session, response)
         return response
 
 
@@ -166,7 +166,7 @@ def make_app():
         """
         captcha_session = await request_captcha(request)
         response = json("Captcha request successful!", captcha_session.code)
-        captcha_session.encode(response)
+        encode(captcha_session, response)
         return response
 
 
@@ -176,9 +176,8 @@ def make_app():
         Request captcha image.
         """
         captcha_session = await _orm.captcha_session.decode(request)
-        #response = captcha_session.get_image()
         response = get_image()
-        captcha_session.encode(response)
+        encode(captcha_session, response)
         return response
 
 
@@ -199,7 +198,7 @@ def make_app():
         """
         two_step_session = await request_two_step_verification(request)
         response = json("Verification request successful!", two_step_session.code)
-        two_step_session.encode(response)
+        encode(two_step_session, response)
         return response
 
 


### PR DESCRIPTION
More simplifying and DRYness to help with move to ORM agnostic usage